### PR TITLE
fix(all): Add permissions to PR checks workflow

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check-title:
     name: Check PR Title

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,10 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@types/js-yaml": "^4.0.9",
         "js-yaml": "^4.1.0"
+      },
+      "devDependencies": {
+        "@types/js-yaml": "^4.0.9"
       }
     },
     "node_modules/@actions/artifact": {
@@ -4686,6 +4688,7 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {


### PR DESCRIPTION
## Description
This pull request adds explicit permissions to the GitHub Actions workflow configuration to improve security and clarify access levels.

Workflow permissions update:

* [`.github/workflows/pull-request-checks.yml`](diffhunk://#diff-3459c141c1ea4ca3206a0c684a5fe8f06e792edd9799396ec2d458bce8ff6c53R7-R10): Added a `permissions` section to specify `contents: read` and `pull-requests: write` for the workflow.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Affected Actions
- [X] azure-config-loader
- [X] shared (affects all)

## Testing

## Checklist
- [X] PR title follows conventional commit format
- [X] Tests pass locally
- [X] Documentation updated if needed